### PR TITLE
Using try/catch for the raw URL change interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,13 @@ client.on('ready', async () => {
   // Play the radio
   broadcast.play(await ytdl(LIVE));
   // Make interval so radio will automatically recommect to YT every 30 minute because YT will change the raw url every 30m/1 Hour
-  if (!interval) interval = setInterval(broadcast.play, 1800000, ytdl(LIVE));
-
+  if (!interval) {
+    interval = setInterval(async function() {
+      try {
+       await broadcast.play( ytdl(LIVE, { highWaterMark: 100 << 150 }))
+      } catch (e) { return }
+    }, 1800000)
+  }
   if(!channel) return;
   const connection = await channel.join();
   connection.play(broadcast)


### PR DESCRIPTION
With the previous code the bot would meet an hard crash throwing an error ' can not playUnkown ' although using try..catch every **30 minute**s for instance would allow us to suppress errors and hence would re-check if the **raw URL** has changed after an hour. Basically a more efficient approach to make the bot not crash.

- [ ✔ ] **Fixed hard crash on a no URL change event.**